### PR TITLE
Adding a close parenthesis in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ accepts free-form addresses.
 property from `L.Control`. Following the Leaflet-habit, a new `L.Control.Search` can be created
 by `L.control.search(<options>)`, so adding **Leaflet-search** to a Map boils down to:
 
-    map.addControl(L.control.search({ position: 'bottomright' });
+    map.addControl(L.control.search({ position: 'bottomright' }));
     
 ## Geocoder ##
 


### PR DESCRIPTION
Updating the readme to have a matching parenthesis for the add control line to have it be valid if you just copy paste it into a project. 

I know its super minor just figured it was easier to fix rather then open an issue